### PR TITLE
Update framework scheme, change `SKIP_INSTALL` & `BUILD_LIBRARY_FOR_DISTRIBUTION`  parameters

### DIFF
--- a/LifoCollections/LifoCollections.xcodeproj/project.pbxproj
+++ b/LifoCollections/LifoCollections.xcodeproj/project.pbxproj
@@ -421,6 +421,7 @@
 		BF13FFF92BED460D00C1686C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "";
@@ -450,7 +451,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "maxim-mitin.framework.miltiplatform.lifoCollections.LifoCollections";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = auto;
-				SKIP_INSTALL = YES;
+				SKIP_INSTALL = NO;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -462,6 +463,7 @@
 		BF13FFFA2BED460D00C1686C /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "";
@@ -491,7 +493,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "maxim-mitin.framework.miltiplatform.lifoCollections.LifoCollections";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = auto;
-				SKIP_INSTALL = YES;
+				SKIP_INSTALL = NO;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
## Description
For correct XCFramework creation and distribution we need to change few settings in framework scheme that mentioned in this [documentation](https://developer.apple.com/documentation/xcode/creating-a-multi-platform-binary-framework-bundle)

## List of changes
In `project.pbxproj` file updated values for parameters:
- `SKIP_INSTALL ` set to `NO`
- `BUILD_LIBRARY_FOR_DISTRIBUTION` set to `YES`

## Related PR
- All the changes from this - #23  will be held in this PR
