### PR TITLE
Update `.gitattributes` config file to work with SPM

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 **/*.xcframework/** filter=lfs diff=lfs merge=lfs -text
+**/*.framework/** filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-**/*.xcframework/** filter=lfs diff=lfs merge=lfs -text
-**/*.framework/** filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
## Description

After adding SPM support to framework, need to update `.gitattributes` config, to resolve problems when adding framework via SPM from GitHub repository to work with both SPM and `.xcframework` binary files.

## List of changes
- added rule `**/*.framework/** filter=lfs diff=lfs merge=lfs -text` to `.gitattributes` file