### PR TITLE
Delete `.gitattributes` to remove `gitLFS` support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-**/*.xcframework/** filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
## Description

Since SPM support is being added to the repository, there is no longer a need for GitLFS.

## List of changes

- Deleted `. gitattributes ` file from repository 